### PR TITLE
Updated BehaviourDsl with Magnet pattern

### DIFF
--- a/modules/core/src/main/scala/io/strongtyped/funcqrs/dsl/BehaviorDsl.scala
+++ b/modules/core/src/main/scala/io/strongtyped/funcqrs/dsl/BehaviorDsl.scala
@@ -150,15 +150,15 @@ object BehaviorDsl {
         def validateAsync(cmd: Command)(implicit ec: ExecutionContext): Future[Event] = {
           processCreationalCmds
             .lift(cmd)
-            .map(_.apply())
-            .getOrElse(fallbackOnCreation(cmd).apply())
+            .getOrElse(fallbackOnCreation(cmd))
+            .apply()
         }
 
         def validateAsync(cmd: Command, aggregate: A)(implicit ec: ExecutionContext): Future[Events] = {
           processUpdateCommands
             .lift(aggregate, cmd)
-            .map(_.apply())
-            .getOrElse(fallbackOnUpdate(aggregate, cmd).apply())
+            .getOrElse(fallbackOnUpdate(aggregate, cmd))
+            .apply()
         }
 
         def applyEvent(evt: Event): A = {

--- a/modules/core/src/main/scala/io/strongtyped/funcqrs/dsl/BehaviorDsl.scala
+++ b/modules/core/src/main/scala/io/strongtyped/funcqrs/dsl/BehaviorDsl.scala
@@ -1,10 +1,8 @@
 package io.strongtyped.funcqrs.dsl
 
 import io.strongtyped.funcqrs.{Aggregate, _}
-
 import scala.collection.immutable
-import scala.concurrent.{ExecutionContext, Future}
-import scala.util.Try
+import scala.concurrent.{Future, ExecutionContext}
 
 object BehaviorDsl {
 
@@ -12,51 +10,48 @@ object BehaviorDsl {
 
     type Protocol = A#Protocol
 
-    // from Cmd to Future[Event]
-    type CommandToEventFuture = PartialFunction[Protocol#ProtocolCommand, Future[Protocol#ProtocolEvent]]
+    sealed trait EventMagnet {
+      def apply(): Future[Protocol#ProtocolEvent]
+    }
 
-    // from Cmd to Event
-    type CommandToEvent = PartialFunction[Protocol#ProtocolCommand, Protocol#ProtocolEvent]
+    object EventMagnet {
+      implicit def fromSingleEvent(event: Protocol#ProtocolEvent): EventMagnet =
+        new EventMagnet {
+          def apply() = Future.successful(event)
+        }
 
-    // from Cmd to Exception
-    type CommandToFailure = PartialFunction[Protocol#ProtocolCommand, CommandException]
+      implicit def fromAsyncSingleEvent(event: Future[Protocol#ProtocolEvent])(implicit ec: ExecutionContext): EventMagnet =
+        new EventMagnet {
+          def apply() = event
+        }
+
+      implicit def fromException(ex: CommandException): EventMagnet =
+        new EventMagnet {
+          def apply() = Future.failed(ex)
+        }
+    }
+
+    // from Cmd to EventMagnet
+    type CommandToEventMagnet = PartialFunction[Protocol#ProtocolCommand, EventMagnet]
 
     // from Event to new Aggregate
     type EventToAggregate = PartialFunction[Protocol#ProtocolEvent, A]
 
     // Creation ------------------------------------------------------
-    private var _acceptFunction: CommandToEventFuture = PartialFunction.empty
-    private var _rejectFunction: CommandToFailure = PartialFunction.empty
+    private var _processCommandFunction: CommandToEventMagnet = PartialFunction.empty
     private var _handleEventFunction: EventToAggregate = PartialFunction.empty
 
-    private[BehaviorDsl] def acceptFunction = _acceptFunction
-
-    private[BehaviorDsl] def rejectFunction = {
-      val lifted: CommandToEventFuture = {
-        case e if _rejectFunction.isDefinedAt(e) => Future.failed(_rejectFunction(e))
-      }
-      lifted
-    }
-
-    val fallbackFunction: CommandToFailure = {
+    private[BehaviorDsl] def processCommandFunction = _processCommandFunction
+    
+    val fallbackFunction: CommandToEventMagnet = {
       case cmd => new CommandException(s"Invalid command $cmd")
     }
 
     private[BehaviorDsl] def handleEventFunction = _handleEventFunction
 
-    def emitsAsyncEvent(pf: CommandToEventFuture): Unit = {
-      _acceptFunction = _acceptFunction orElse pf
+    def processesCommands(pf: CommandToEventMagnet): Unit = {
+      _processCommandFunction = _processCommandFunction orElse pf
     }
-
-    def emitsEvent(pf: CommandToEvent): Unit = {
-      emitsAsyncEvent(liftFuture(pf))
-    }
-
-
-    def rejectsCommands(pf: CommandToFailure): Unit = {
-      _rejectFunction = _rejectFunction orElse pf
-    }
-
 
     def acceptsEvents(pf: EventToAggregate): Unit = {
       _handleEventFunction = _handleEventFunction orElse pf
@@ -68,68 +63,63 @@ object BehaviorDsl {
 
     type Protocol = A#Protocol
 
-    // from Aggregate + Cmd to Future[Event]
-    type CommandToEventFuture = PartialFunction[(A, Protocol#ProtocolCommand), Future[Protocol#ProtocolEvent]]
-    // from Aggregate + Cmd to Event
-    type CommandToEvent = PartialFunction[(A, Protocol#ProtocolCommand), Protocol#ProtocolEvent]
+    sealed trait EventMagnet {
+      def apply(): Future[Seq[Protocol#ProtocolEvent]]
+    }
 
-    // from Aggregate + Cmd to Future[Seq[Event]]
-    type CommandToEventsFuture = PartialFunction[(A, Protocol#ProtocolCommand), Future[immutable.Seq[Protocol#ProtocolEvent]]]
+    object EventMagnet {
+      implicit def fromSingleEvent(event: Protocol#ProtocolEvent): EventMagnet =
+        new EventMagnet {
+          def apply() = Future.successful(immutable.Seq(event))
+        }
 
-    // from Aggregate + Cmd to Seq[Event]
-    type CommandToEvents = PartialFunction[(A, Protocol#ProtocolCommand), immutable.Seq[Protocol#ProtocolEvent]]
+      implicit def fromEventSeq(events: immutable.Seq[Protocol#ProtocolEvent]): EventMagnet =
+        new EventMagnet {
+          def apply() = Future.successful(events)
+        }
 
-    // from Aggregate + Cmd to Exception
-    type CommandToFailure = PartialFunction[(A, Protocol#ProtocolCommand), CommandException]
+      implicit def fromAsyncSingleEvent(event: Future[Protocol#ProtocolEvent])
+        (implicit ec: ExecutionContext): EventMagnet =
+        new EventMagnet {
+          def apply() = event.map(Seq(_))
+        }
+
+      implicit def fromAsyncEventSeq(events: Future[immutable.Seq[Protocol#ProtocolEvent]])
+        (implicit ec: ExecutionContext): EventMagnet =
+        new EventMagnet {
+          def apply() = events
+        }
+      
+      implicit def fromException(ex: CommandException): EventMagnet =
+        new EventMagnet {
+          def apply() = Future.failed(ex)
+        }
+    }
+
+    // from Aggregate + Cmd to EventMagnet
+    type CommandToEventMagnet = PartialFunction[(A, Protocol#ProtocolCommand), EventMagnet]
 
     type EventToAggregate = PartialFunction[(A, Protocol#ProtocolEvent), A]
 
     // Updates --------------------------------------------------------
-    private var _acceptFunction: CommandToEventsFuture = PartialFunction.empty
-    private var _rejectFunction: CommandToFailure = PartialFunction.empty
+    private var _processCommandFunction: CommandToEventMagnet = PartialFunction.empty
     private var _handleEventFunction: EventToAggregate = PartialFunction.empty
 
-    val fallbackFunction: CommandToFailure = {
+    val fallbackFunction: CommandToEventMagnet = {
       case (agg, cmd) => new CommandException(s"Invalid command $cmd for aggregate ${agg.id}")
     }
 
-    private[BehaviorDsl] def acceptFunction = _acceptFunction
-
-    private[BehaviorDsl] def rejectFunction = {
-      val lifted: CommandToEventsFuture = {
-        case e if _rejectFunction.isDefinedAt(e) => Future.failed(_rejectFunction(e))
-      }
-      lifted
-    }
+    private[BehaviorDsl] def processCommandFunction = _processCommandFunction
 
     private[BehaviorDsl] def handleEventFunction = _handleEventFunction
 
-
-    def emitsManyEventsAsync(pf: CommandToEventsFuture): Unit = {
-      _acceptFunction = _acceptFunction orElse pf
-    }
-
-    def emitsSingleEventAsync(pf: CommandToEventFuture)(implicit ec: ExecutionContext): Unit = {
-      emitsManyEventsAsync(mapSeq(pf))
-    }
-
-    def emitsSingleEvent(pf: CommandToEvent): Unit = {
-      emitsManyEvents(liftSeq(pf))
-    }
-
-    def emitsManyEvents(pf: CommandToEvents): Unit = {
-      emitsManyEventsAsync(liftFuture(pf))
-    }
-
-    def rejectsCommands(pf: CommandToFailure): Unit = {
-      _rejectFunction = _rejectFunction orElse pf
+    def processesCommands(pf: CommandToEventMagnet): Unit = {
+      _processCommandFunction = _processCommandFunction orElse pf
     }
 
     def acceptsEvents(pf: EventToAggregate): Unit = {
       _handleEventFunction = _handleEventFunction orElse pf
     }
-
-
   }
 
   class BehaviorBuilder[A <: Aggregate](val creation: CreationBuilder[A], val updates: UpdatesBuilder[A]) {
@@ -149,26 +139,26 @@ object BehaviorDsl {
 
       new Behavior[A] {
 
-        private val acceptCreationalCmds = creation.acceptFunction
-        private val rejectCreationalCmds = creation.rejectFunction
+        private val processCreationalCmds = creation.processCommandFunction
         private val fallbackOnCreation = creation.fallbackFunction
         private val handleCreationalEvents = creation.handleEventFunction
 
-        private val acceptUpdateCommands = updates.acceptFunction
-        private val rejectUpdateCommands = updates.rejectFunction
+        private val processUpdateCommands = updates.processCommandFunction
         private val fallbackOnUpdate = updates.fallbackFunction
         private val handleEvents = updates.handleEventFunction
 
         def validateAsync(cmd: Command)(implicit ec: ExecutionContext): Future[Event] = {
-          (rejectCreationalCmds orElse acceptCreationalCmds)
+          processCreationalCmds
             .lift(cmd)
-            .getOrElse(Future.failed(fallbackOnCreation(cmd)))
+            .map(_.apply())
+            .getOrElse(fallbackOnCreation(cmd).apply())
         }
 
         def validateAsync(cmd: Command, aggregate: A)(implicit ec: ExecutionContext): Future[Events] = {
-          (rejectUpdateCommands orElse acceptUpdateCommands)
+          processUpdateCommands
             .lift(aggregate, cmd)
-            .getOrElse(Future.failed(fallbackOnUpdate(aggregate, cmd)))
+            .map(_.apply())
+            .getOrElse(fallbackOnUpdate(aggregate, cmd).apply())
         }
 
         def applyEvent(evt: Event): A = {
@@ -185,21 +175,5 @@ object BehaviorDsl {
 
   def behaviorFor[A <: Aggregate]: BehaviorBuilder[A] =
     new BehaviorBuilder(new CreationBuilder, new UpdatesBuilder)
-
-
-  private def mapSeq[A, B](pf: PartialFunction[A, Future[B]])(implicit ec: ExecutionContext): PartialFunction[A, Future[immutable.Seq[B]]] = {
-    case e if pf.isDefinedAt(e) => pf(e).map { value => immutable.Seq(value) }
-  }
-
-  private def liftFuture[A, B](pf: PartialFunction[A, B]): PartialFunction[A, Future[B]] = {
-    case e if pf.isDefinedAt(e) => Future.fromTry(Try(pf(e)))
-  }
-
-  private def liftSeq[A, B](pf: PartialFunction[A, B]): PartialFunction[A, immutable.Seq[B]] = {
-    case e if pf.isDefinedAt(e) => immutable.Seq(pf(e))
-  }
-
-  private def liftSeqFuture[A, B](pf: PartialFunction[A, B]): PartialFunction[A, Future[immutable.Seq[B]]] = liftFuture(liftSeq(pf))
-
 
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
 
   //------------------------------------------------------------------------------------------------------------
   // Akka Module
-  val akkaVersion           =   "2.4.0-RC3"
+  val akkaVersion           =   "2.4.0"
   val akkaPersistence       =   "com.typesafe.akka"           %%  "akka-persistence"  % akkaVersion
   val akkaSlf4j             =   "com.typesafe.akka"           %%  "akka-slf4j"        % akkaVersion
   val akkaTestKit           =   "com.typesafe.akka"           %%  "akka-testkit"      % akkaVersion     % "test"

--- a/samples/cqrs-akka-play/src/main/scala/shop/domain/model/Customer.scala
+++ b/samples/cqrs-akka-play/src/main/scala/shop/domain/model/Customer.scala
@@ -158,7 +158,7 @@ object Customer {
 
 
     behaviorFor[Customer].whenConstructing { it =>
-      it.emitsEvent {
+      it.processesCommands {
         case cmd: CreateCustomer =>
           CustomerCreated(cmd.name, cmd.vatNumber, metadata(id, cmd))
       }
@@ -170,7 +170,7 @@ object Customer {
 
     }.whenUpdating { it =>
 
-      it.emitsSingleEvent {
+      it.processesCommands {
 
         case (_, cmd: ChangeName)          => NameChanged(cmd.name, metadata(id, cmd))
         case (_, cmd: ChangeAddressStreet) => AddressStreetChanged(cmd.street, metadata(id, cmd))
@@ -181,9 +181,6 @@ object Customer {
         case (customer, cmd: AddVatNumber) if customer.doesNotHaveVatNumber         => VatNumberAdded(cmd.vat, metadata(id, cmd))
         case (customer, cmd: RemoveVatNumber.type) if customer.doesNotHaveVatNumber => VatNumberRemoved(metadata(id, cmd))
 
-      }
-
-      it.emitsManyEvents {
         case (_, cmd: AddAddress) =>
           immutable.Seq(
             AddressStreetChanged(cmd.address.street, metadata(id, cmd)),

--- a/samples/cqrs-akka-play/src/main/scala/shop/domain/model/Order.scala
+++ b/samples/cqrs-akka-play/src/main/scala/shop/domain/model/Order.scala
@@ -7,6 +7,8 @@ import io.strongtyped.funcqrs.dsl.BehaviorDsl._
 import io.strongtyped.funcqrs.json.TypedJson.{TypeHintFormat, _}
 import play.api.libs.json._
 
+import scala.concurrent.ExecutionContext
+
 sealed trait Status
 
 case object Open extends Status
@@ -77,7 +79,7 @@ object Order {
 
     behaviorFor[Order].whenConstructing { it =>
 
-      it.emitsEvent {
+      it.processesCommands {
         case cmd: CreateOrder => OrderCreated(cmd.customerId, metadata(orderNum, cmd))
       }
 
@@ -87,22 +89,7 @@ object Order {
 
     }.whenUpdating { it =>
 
-      it.emitsSingleEvent {
-
-        case (order, cmd: AddProduct) if order.status == Open =>
-          ProductAdded(cmd.productNumber, metadata(orderNum, cmd))
-
-        case (order, cmd: RemoveProduct) if order.status == Open =>
-          ProductRemoved(cmd.productNumber, metadata(orderNum, cmd))
-
-        case (order, cmd: Execute.type) if order.status == Open =>
-          OrderExecuted(metadata(orderNum, cmd))
-
-        case (order, cmd: Cancel.type) if order.status == Open =>
-          OrderCancelled(metadata(orderNum, cmd))
-      }
-
-      it.rejectsCommands {
+      it.processesCommands {
 
         case (order, cmd: Execute.type) if order.status == Executed =>
           new CommandException(s"Order is already executed")
@@ -119,6 +106,17 @@ object Order {
         case (order, _) if order.status == Cancelled =>
           new CommandException(s"Can't modify a cancelled order")
 
+        case (order, cmd: AddProduct) if order.status == Open =>
+          ProductAdded(cmd.productNumber, metadata(orderNum, cmd))
+
+        case (order, cmd: RemoveProduct) if order.status == Open =>
+          ProductRemoved(cmd.productNumber, metadata(orderNum, cmd))
+
+        case (order, cmd: Execute.type) if order.status == Open =>
+          OrderExecuted(metadata(orderNum, cmd))
+
+        case (order, cmd: Cancel.type) if order.status == Open =>
+          OrderCancelled(metadata(orderNum, cmd))
 
       }
 

--- a/samples/cqrs-akka-play/src/main/scala/shop/domain/service/CustomerModule.scala
+++ b/samples/cqrs-akka-play/src/main/scala/shop/domain/service/CustomerModule.scala
@@ -3,7 +3,7 @@ package shop.domain.service
 import akka.actor.{ActorRef, Props}
 import com.softwaremill.macwire._
 import io.strongtyped.funcqrs.Behavior
-import io.strongtyped.funcqrs.akka.{AggregateManager, AssignedAggregateId, ProjectionActor}
+import io.strongtyped.funcqrs.akka._
 import shop.api.AkkaModule
 import shop.app.LevelDbProjectionSource
 import shop.domain.model.{Customer, CustomerId, CustomerView}
@@ -27,6 +27,8 @@ class CustomerAggregateManager extends AggregateManager with AssignedAggregateId
   type AggregateType = Customer
 
   def behavior(id: CustomerId): Behavior[Customer] = Customer.behavior(id)
+
+  override def aggregatePassivationStrategy = AggregatePassivationStrategy(maxChildren = Some(MaxChildren(40, 20)))
 
 }
 

--- a/samples/cqrs-akka-play/src/main/scala/shop/domain/service/OrderModule.scala
+++ b/samples/cqrs-akka-play/src/main/scala/shop/domain/service/OrderModule.scala
@@ -2,7 +2,7 @@ package shop.domain.service
 
 import akka.actor.{ActorRef, Props}
 import com.softwaremill.macwire._
-import io.strongtyped.funcqrs.akka.{AssignedAggregateId, AggregateManager, ProjectionActor}
+import io.strongtyped.funcqrs.akka._
 import io.strongtyped.funcqrs.{Behavior, Tag}
 import shop.api.AkkaModule
 import shop.app.LevelDbProjectionSource
@@ -29,6 +29,9 @@ trait OrderModule extends AkkaModule {
 class OrderAggregateManager extends AggregateManager with AssignedAggregateId {
   type AggregateType = Order
   def behavior(id: OrderNumber): Behavior[Order] = Order.behavior(id)
+
+  override def aggregatePassivationStrategy = AggregatePassivationStrategy(maxChildren = Some(MaxChildren(40, 20)))
+
 }
 
 class OrderViewProjectionActor(val projection: OrderViewProjection) extends ProjectionActor with LevelDbProjectionSource {

--- a/samples/cqrs-akka-play/src/main/scala/shop/domain/service/ProductModule.scala
+++ b/samples/cqrs-akka-play/src/main/scala/shop/domain/service/ProductModule.scala
@@ -2,7 +2,7 @@ package shop.domain.service
 
 import akka.actor.{ActorRef, Props}
 import com.softwaremill.macwire._
-import io.strongtyped.funcqrs.akka.{AggregateManager, AssignedAggregateId, ProjectionActor}
+import io.strongtyped.funcqrs.akka._
 import io.strongtyped.funcqrs.{Behavior, Tag}
 import shop.api.AkkaModule
 import shop.app.LevelDbProjectionSource
@@ -29,6 +29,8 @@ trait ProductModule extends AkkaModule {
 class ProductAggregateManager extends AggregateManager with AssignedAggregateId {
   type AggregateType = Product
   def behavior(id: ProductNumber): Behavior[Product] = Product.behavior(id)
+
+  override def aggregatePassivationStrategy = AggregatePassivationStrategy(maxChildren = Some(MaxChildren(40, 20)))
 }
 
 class ProductViewProjectionActor(val projection: ProductViewProjection) extends ProjectionActor with LevelDbProjectionSource {

--- a/samples/cqrs-akka-play/src/test/scala/shop/domain/model/ProductTest.scala
+++ b/samples/cqrs-akka-play/src/test/scala/shop/domain/model/ProductTest.scala
@@ -61,6 +61,6 @@ class ProductTest extends FlatSpec with Matchers with FutureTry with TryValues {
         (_, updated) <- productBehavior.applyCommand(ChangePrice(-1), prod)
       } yield updated
 
-    result.asTry.failure.exception.getMessage shouldBe "Price is too low!"
+    result.asTry.failure.exception.getMessage shouldBe "Can't decrease the price"
   }
 }


### PR DESCRIPTION
I used the magnet pattern to eliminate the need for separate command processing methods for different return values.  So essentially we can have one processesCommands partial function that can return:

- one event
- seq of events
- future event
- future sequence of events
- CommandException

...instead of all the emitsSingleEvent, emitsManyEvents, emitsSingleEventAsync, emitsManyEventsAsync and rejectsCommands methods 