### PR TITLE
configurable datetime type in metadata, to allow jodatime or other libs

### DIFF
--- a/modules/core/src/main/scala/io/strongtyped/funcqrs/Metadata.scala
+++ b/modules/core/src/main/scala/io/strongtyped/funcqrs/Metadata.scala
@@ -2,7 +2,6 @@ package io.strongtyped.funcqrs
 
 import java.time.OffsetDateTime
 
-
 /**
  * Holds Metadata information such as:
  * - aggregateId
@@ -17,12 +16,18 @@ import java.time.OffsetDateTime
 trait Metadata {
 
   type Id <: AggregateID
+  type DateTime
 
   def aggregateId: Id
   def commandId: CommandId
   def eventId: EventId
-  def date: OffsetDateTime
+  def date: DateTime
   def tags: Set[Tag]
+}
+
+trait JavaTime {
+  self: Metadata =>
+  type DateTime = OffsetDateTime
 }
 
 /**
@@ -37,7 +42,7 @@ trait MetadataFacet[M <: Metadata] {
   final def id: EventId = metadata.eventId
   final def aggregateId: M#Id = metadata.aggregateId
   final def commandId: CommandId = metadata.commandId
-  final def date: OffsetDateTime = metadata.date
+  final def date: M#DateTime = metadata.date
   final def tags: Set[Tag] = metadata.tags
 }
 

--- a/samples/cqrs-akka-play/src/main/scala/shop/domain/model/Customer.scala
+++ b/samples/cqrs-akka-play/src/main/scala/shop/domain/model/Customer.scala
@@ -115,7 +115,7 @@ object CustomerProtocol extends ProtocolDef {
                               commandId: CommandId,
                               eventId: EventId = EventId(),
                               date: OffsetDateTime = OffsetDateTime.now(),
-                              tags: Set[Tag] = Set()) extends Metadata {
+                              tags: Set[Tag] = Set()) extends Metadata with JavaTime {
 
     type Id = CustomerId
   }

--- a/samples/cqrs-akka-play/src/main/scala/shop/domain/model/Order.scala
+++ b/samples/cqrs-akka-play/src/main/scala/shop/domain/model/Order.scala
@@ -170,7 +170,7 @@ object OrderProtocol extends ProtocolDef {
                            commandId: CommandId,
                            eventId: EventId = EventId(),
                            date: OffsetDateTime = OffsetDateTime.now(),
-                           tags: Set[Tag] = Set()) extends Metadata {
+                           tags: Set[Tag] = Set()) extends Metadata with JavaTime {
 
     type Id = OrderNumber
   }

--- a/samples/cqrs-akka-play/src/main/scala/shop/domain/model/Product.scala
+++ b/samples/cqrs-akka-play/src/main/scala/shop/domain/model/Product.scala
@@ -42,7 +42,7 @@ object ProductProtocol extends ProtocolDef {
                              commandId: CommandId,
                              eventId: EventId = EventId(),
                              date: OffsetDateTime = OffsetDateTime.now(),
-                             tags: Set[Tag] = Set()) extends Metadata {
+                             tags: Set[Tag] = Set()) extends Metadata with JavaTime {
     type Id = ProductNumber
   }
 


### PR DESCRIPTION
Hi there, just a simple one this time!  As we use jodatime in our app rather than javatime, it's slightly annoying to have to convert between the two and write new serialisation routines etc for the event metadata.  This pull request just allows you to specify the type of the date in the metadata and mixin a predefined trait for javatime. This allows us to create a similar mixin trait for jodatime in our app.