### PR TITLE
Refactored slightly to add an extra module containing leveldb specific classes.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ lazy val root = Project(
   settings = Seq(
     publishArtifact := false
   )
-) aggregate(funCqrs, funCqrsAkka, playApp)
+) aggregate(funCqrs, funCqrsAkka, funCqrsLevelDb, playApp)
 
 
 // Core ==========================================
@@ -30,7 +30,6 @@ lazy val funCqrs = Project(
 )
 //================================================
 
-
 // Akka integration ==============================
 lazy val funCqrsAkka = Project(
   id = "fun-cqrs-akka",
@@ -39,6 +38,14 @@ lazy val funCqrsAkka = Project(
 ) dependsOn (funCqrs % "compile->compile;test->test")
 //================================================
 
+// LevelDB integration ===========================
+lazy val funCqrsLevelDb = Project(
+  id = "fun-cqrs-leveldb",
+  base = file("modules/leveldb"),
+  settings = levelDbDeps
+).dependsOn(funCqrs % "compile->compile;test->test")
+  .dependsOn(funCqrsAkka % "compile->compile;test->test")
+//================================================
 
 // #####################################################
 // #                     SAMPLES                      #
@@ -56,6 +63,7 @@ lazy val playApp = Project(
   .disablePlugins(PlayLayoutPlugin)
   .dependsOn(funCqrs % "compile->compile;test->test")
   .dependsOn(funCqrsAkka % "compile->compile;test->test")
+  .dependsOn(funCqrsLevelDb % "compile->compile;test->test")
 //================================================
 
 addCommandAlias("runPlaySample", "fun-cqrs-akka-play-sample/run")

--- a/modules/core/src/test/scala/io/strongtyped/funcqrs/FutureTry.scala
+++ b/modules/core/src/test/scala/io/strongtyped/funcqrs/FutureTry.scala
@@ -1,13 +1,11 @@
 package io.strongtyped.funcqrs
 
-import org.scalatest.concurrent.ScalaFutures
-
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 import scala.language.postfixOps
 import scala.util.Try
 
-trait FutureTry extends ScalaFutures {
+trait FutureTry {
 
   implicit class FutureTryOps[A](fut: Future[A]) {
     def asTry = {

--- a/modules/leveldb/src/main/scala/io/strongtyped/funcqrs/leveldb/LevelDbTaggedEventsSource.scala
+++ b/modules/leveldb/src/main/scala/io/strongtyped/funcqrs/leveldb/LevelDbTaggedEventsSource.scala
@@ -1,4 +1,4 @@
-package shop.app
+package io.strongtyped.funcqrs.leveldb
 
 import akka.actor.Actor
 import akka.persistence.query.journal.leveldb.scaladsl.LeveldbReadJournal

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,15 +7,11 @@ object Dependencies {
   //------------------------------------------------------------------------------------------------------------
   // io.strongtyped.funcqrs core
   val scalaLogging          =  "com.typesafe.scala-logging" %%  "scala-logging"    % "3.1.0"
-  val scalaTest             =  "org.scalatest"              %%  "scalatest"        % "2.2.1"         % "test"
   
   val mainDeps = Seq(
-    libraryDependencies ++= Seq(scalaLogging),
-    libraryDependencies ++= Seq(scalaTest)
+    libraryDependencies ++= Seq(scalaLogging)
   )
   //------------------------------------------------------------------------------------------------------------
-
-
 
   //------------------------------------------------------------------------------------------------------------
   // Akka Module
@@ -25,32 +21,38 @@ object Dependencies {
   val akkaSlf4j             =   "com.typesafe.akka"           %%  "akka-slf4j"        % akkaVersion
   val akkaTestKit           =   "com.typesafe.akka"           %%  "akka-testkit"      % akkaVersion     % "test"
 
-  val levelDb               =   "org.iq80.leveldb"            %   "leveldb"           % "0.7"
-  val levelDbJNI            =   "org.fusesource.leveldbjni"   %   "leveldbjni-all"    % "1.8"
-
   val akkaStreams           =   "com.typesafe.akka"           %%  "akka-stream-experimental"            % "1.0"
   val akkaPersistenceQuery  =   "com.typesafe.akka"           %%  "akka-persistence-query-experimental" % akkaVersion
 
   val akkaDeps = Seq(
     libraryDependencies ++= Seq(akkaActor, akkaPersistence, akkaSlf4j, akkaTestKit),
-    libraryDependencies ++= Seq(levelDb, levelDbJNI),
     // experimental
     libraryDependencies ++= Seq(akkaPersistenceQuery, akkaStreams)
   )
   //------------------------------------------------------------------------------------------------------------
 
+  //------------------------------------------------------------------------------------------------------------
+  // LevelDb Module
+  val levelDb               =   "org.iq80.leveldb"            %   "leveldb"           % "0.7"
+  val levelDbJNI            =   "org.fusesource.leveldbjni"   %   "leveldbjni-all"    % "1.8"
 
+  val levelDbDeps = Seq(
+    libraryDependencies ++= Seq(levelDb, levelDbJNI)
+  )
+  //------------------------------------------------------------------------------------------------------------
 
   //------------------------------------------------------------------------------------------------------------
   //  PLAY Sample
   val macwireVersion    =   "1.0.7"
-  val macwireMacros     =   "com.softwaremill.macwire" %% "macros"  % macwireVersion
-  val macwireRuntime    =   "com.softwaremill.macwire" %% "runtime" % macwireVersion
+  val macwireMacros     =   "com.softwaremill.macwire" %% "macros"    % macwireVersion
+  val macwireRuntime    =   "com.softwaremill.macwire" %% "runtime"   % macwireVersion
+  val scalaTest         =   "org.scalatest"            %% "scalatest" % "2.2.1"         % "test"
 
   val playSampleDeps = Seq(
     libraryDependencies += macwireRuntime,
-    libraryDependencies += macwireMacros
-  ) ++ mainDeps ++ akkaDeps
+    libraryDependencies += macwireMacros,
+    libraryDependencies += scalaTest
+  )
   //------------------------------------------------------------------------------------------------------------
 
 }

--- a/samples/cqrs-akka-play/src/main/scala/shop/domain/service/CustomerModule.scala
+++ b/samples/cqrs-akka-play/src/main/scala/shop/domain/service/CustomerModule.scala
@@ -4,8 +4,8 @@ import akka.actor.{ActorRef, Props}
 import com.softwaremill.macwire._
 import io.strongtyped.funcqrs.Behavior
 import io.strongtyped.funcqrs.akka._
+import io.strongtyped.funcqrs.leveldb.LevelDbTaggedEventsSource
 import shop.api.AkkaModule
-import shop.app.LevelDbTaggedEventsSource
 import shop.domain.model.{Customer, CustomerId, CustomerView}
 
 trait CustomerModule extends AkkaModule {

--- a/samples/cqrs-akka-play/src/main/scala/shop/domain/service/OrderModule.scala
+++ b/samples/cqrs-akka-play/src/main/scala/shop/domain/service/OrderModule.scala
@@ -3,9 +3,9 @@ package shop.domain.service
 import akka.actor.{ActorRef, Props}
 import com.softwaremill.macwire._
 import io.strongtyped.funcqrs.akka._
+import io.strongtyped.funcqrs.leveldb.LevelDbTaggedEventsSource
 import io.strongtyped.funcqrs.{Projection, Behavior, Tag}
 import shop.api.AkkaModule
-import shop.app.LevelDbTaggedEventsSource
 import shop.domain.model.{Order, OrderNumber, OrderView}
 
 trait OrderModule extends AkkaModule {

--- a/samples/cqrs-akka-play/src/main/scala/shop/domain/service/ProductModule.scala
+++ b/samples/cqrs-akka-play/src/main/scala/shop/domain/service/ProductModule.scala
@@ -3,9 +3,9 @@ package shop.domain.service
 import akka.actor.{ActorRef, Props}
 import com.softwaremill.macwire._
 import io.strongtyped.funcqrs.akka._
+import io.strongtyped.funcqrs.leveldb.LevelDbTaggedEventsSource
 import io.strongtyped.funcqrs.{Behavior, Tag}
 import shop.api.AkkaModule
-import shop.app.LevelDbTaggedEventsSource
 import shop.domain.model.{Product, ProductNumber, ProductView}
 
 

--- a/samples/cqrs-akka-play/src/test/scala/shop/domain/model/ProductTest.scala
+++ b/samples/cqrs-akka-play/src/test/scala/shop/domain/model/ProductTest.scala
@@ -1,10 +1,8 @@
 package shop.domain.model
 
-import org.scalatest.{FlatSpec, Matchers, TryValues}
 import io.strongtyped.funcqrs.FutureTry
-
+import org.scalatest.{FlatSpec, Matchers, TryValues}
 import shop.domain.model.ProductProtocol._
-
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class ProductTest extends FlatSpec with Matchers with FutureTry with TryValues {


### PR DESCRIPTION
I moved LevelDbTaggedEventsSource from the sample project into it's own module, so I can reuse it in my project.  We can also add other leveldb specific stuff in here as required, and also other modules for different read journal implementations (as they become available).