### PR TITLE
Can now pass extra parameters to CQRSSystem.projection method

### DIFF
--- a/modules/akka/src/main/scala/io/strongtyped/funcqrs/akka/CQRSSystem.scala
+++ b/modules/akka/src/main/scala/io/strongtyped/funcqrs/akka/CQRSSystem.scala
@@ -1,7 +1,5 @@
 package io.strongtyped.funcqrs.akka
 
-import java.util.UUID
-
 import akka.actor.{ActorRef, ActorSystem, Props}
 import akka.pattern._
 import akka.util.Timeout
@@ -10,7 +8,6 @@ import io.strongtyped.funcqrs.Projection
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.reflect.ClassTag
-import scala.util.{Failure, Success, Try}
 
 class CQRSSystem(actorSystem: ActorSystem) extends LazyLogging {
 
@@ -24,10 +21,15 @@ class CQRSSystem(actorSystem: ActorSystem) extends LazyLogging {
    * Note that a ProjectionActor is required to have a unique name.
    * This unique name is used to identify this Actor but also as persistenceId for the offset.
    *
-   * Moreover, a ProjectionActor is required to have a constructor receiving the name:String and the projection:Projection.
+   * Moreover, a ProjectionActor is required to have a constructor receiving name:String and projection:Projection
+   * as the first two parameters.
    */
-  def projection[P <: ProjectionActor](name: String, projection: Projection)(implicit classTag: ClassTag[P]): Future[ActorRef] = {
-    val props = Props(classTag.runtimeClass, name, projection)
+  def projection[P <: ProjectionActor](name: String, projection: Projection, args: AnyRef*)
+    (implicit classTag: ClassTag[P]): Future[ActorRef] = {
+
+    val propsArgs = Seq(name, projection) ++ args.toSeq
+
+    val props = Props(classTag.runtimeClass, propsArgs: _*)
     (projectionMonitorActorRef ? ProjectionMonitorActor.CreateProjection(props, name)).mapTo[ActorRef]
   }
 


### PR DESCRIPTION
I needed this due to my ProjectionActor mixing in the PersistedOffsetDb.  I wanted to store the offsets in a Postgresql DB, therefore I needed to pass a repository into my actor. 