### PR TITLE
Use Magnet pattern to avoid having to map to Future[Unit] in Projections

### DIFF
--- a/modules/core/src/main/scala/io/funcqrs/Projection.scala
+++ b/modules/core/src/main/scala/io/funcqrs/Projection.scala
@@ -8,7 +8,7 @@ trait Projection {
 
   final def onEvent(evt: DomainEvent): Future[Unit] = {
     if (receiveEvent.isDefinedAt(evt)) {
-      receiveEvent(evt)
+      receiveEvent(evt).apply()
     }
     else {
       Future.successful(())

--- a/modules/core/src/main/scala/io/funcqrs/package.scala
+++ b/modules/core/src/main/scala/io/funcqrs/package.scala
@@ -1,10 +1,25 @@
 package io
 
 import scala.concurrent.Future
+import scala.language.implicitConversions
 
 package object funcqrs {
 
-  type HandleEvent = PartialFunction[DomainEvent, Future[Unit]]
+  sealed trait FutureMagnet {
+    def apply(): Future[Unit]
+  }
+
+  object FutureMagnet {
+    implicit def fromFutureX[X](x: Future[X]): FutureMagnet =
+      new FutureMagnet {
+        def apply() = {
+          import scala.concurrent.ExecutionContext.Implicits.global
+          x.map(_ => ())
+        }
+      }
+  }
+
+  type HandleEvent = PartialFunction[DomainEvent, FutureMagnet]
 
   @deprecated(message = "Use ProtocolLike instead", since = "0.0.4")
   type ProtocolDef = ProtocolLike

--- a/samples/lottery/src/main/scala/lottery/domain/service/LotteryViewProjection.scala
+++ b/samples/lottery/src/main/scala/lottery/domain/service/LotteryViewProjection.scala
@@ -14,18 +14,16 @@ class LotteryViewProjection(repo: LotteryViewRepo) extends Projection with LazyL
   def receiveEvent: HandleEvent = {
     case e: LotteryCreated     => create(e)
     case e: LotteryUpdateEvent => update(e)
-
   }
 
   def create(e: LotteryCreated): Future[Unit] = {
     repo.save(LotteryView(name = e.name, id = e.metadata.aggregateId))
   }
 
-  def update(e: LotteryUpdateEvent): Future[Unit] = {
+  def update(e: LotteryUpdateEvent): Future[LotteryView] = {
     repo.updateById(e.aggregateId) { lot =>
       updateFunc(lot, e)
-    }.map(_ => ())
-
+    }
   }
 
   private def updateFunc(view: LotteryView, evt: LotteryUpdateEvent): LotteryView = {

--- a/samples/shop/src/main/scala/shop/domain/service/ProductViewProjection.scala
+++ b/samples/shop/src/main/scala/shop/domain/service/ProductViewProjection.scala
@@ -21,13 +21,13 @@ class ProductViewProjection(repo: ProductViewRepo) extends Projection with LazyL
     repo.save(ProductView(e.name, e.description, e.price, e.metadata.aggregateId))
   }
 
-  def update(e: ProductUpdateEvent): Future[Unit] = {
+  def update(e: ProductUpdateEvent): Future[_] = {
 
     logger.debug(s"Updating product $e")
 
     repo.updateById(e.aggregateId) { prod =>
       updateFunc(prod, e)
-    }.map(_ => ())
+    }
 
   }
 


### PR DESCRIPTION
I thought of an alternative to my other PR, using the magnet pattern again to map any Future[T] to Future[Unit] implicitly... I think this is better than spilling the type out all over the place, when we don't need it anyway.  Also allows different methods in the repo to return different Futures.  I updated the samples accordingly. Let me know what you think.