### PR TITLE
Make lastProcessedOffset an Option

### DIFF
--- a/modules/akka/src/main/scala/io/funcqrs/akka/FunCQRS.scala
+++ b/modules/akka/src/main/scala/io/funcqrs/akka/FunCQRS.scala
@@ -167,7 +167,7 @@ object FunCQRS {
       def saveCurrentOffset(offset: Long): Future[Unit]
 
       /** Returns the current offset as persisted in DB */
-      def readOffset: Future[Long]
+      def readOffset: Future[Option[Long]]
 
     }
 

--- a/modules/akka/src/main/scala/io/funcqrs/akka/OffsetPersistence.scala
+++ b/modules/akka/src/main/scala/io/funcqrs/akka/OffsetPersistence.scala
@@ -29,7 +29,7 @@ trait PersistedOffsetCustom extends OffsetPersistence {
   def saveCurrentOffset(offset: Long): Unit
 
   /** Returns the current offset as persisted in DB */
-  def readOffset: Future[Long]
+  def readOffset: Future[Option[Long]]
 
   /** On preStart we read the offset from db and start the events streaming */
   override def preStart(): Unit = {
@@ -62,7 +62,7 @@ trait PersistedOffsetAkka extends OffsetPersistence with PersistentActor with St
 
     case SnapshotOffer(metadata, offset: Long) =>
       log.debug(s"[$persistenceId] snapshot offer - lastProcessedOffset $offset")
-      lastProcessedOffset = offset
+      lastProcessedOffset = Some(offset)
 
     case _: RecoveryCompleted =>
       log.debug(s"[$persistenceId] recovery completed - lastProcessedOffset $lastProcessedOffset")

--- a/modules/akka/src/main/scala/io/funcqrs/akka/ProjectionActor.scala
+++ b/modules/akka/src/main/scala/io/funcqrs/akka/ProjectionActor.scala
@@ -26,7 +26,7 @@ abstract class ProjectionActor(projection: Projection,
 
   implicit val timeout = Timeout(5 seconds)
 
-  var lastProcessedOffset: Long = 0
+  var lastProcessedOffset: Option[Long] = None
 
   def saveCurrentOffset(offset: Long): Unit
 
@@ -34,7 +34,7 @@ abstract class ProjectionActor(projection: Projection,
     log.debug(s"ProjectionActor: starting projection... $projection")
     implicit val mat = ActorMaterializer()
     val actorSink = Sink.actorSubscriber(Props(classOf[ForwardingActorSubscriber], self, WatermarkRequestStrategy(10)))
-    sourceProvider.source(lastProcessedOffset + 1).runWith(actorSink)
+    sourceProvider.source(lastProcessedOffset.map(_ + 1).getOrElse(0)).runWith(actorSink)
   }
 
   override def receive: Receive = acceptingEvents
@@ -201,7 +201,7 @@ class ProjectionActorWithCustomOffsetPersistence(projection: Projection,
   }
 
   /** Returns the current offset as persisted in DB */
-  def readOffset: Future[Long] = customOffsetPersistence.readOffset
+  def readOffset: Future[Option[Long]] = customOffsetPersistence.readOffset
 }
 
 object ProjectionActorWithCustomOffsetPersistence {


### PR DESCRIPTION
Makes sure that offset starts from 0 when using `OffsetPersistence` and gives `PersistedOffsetDb` the opportunity to return a None from readOffset when there is no offset persisted, which will also start the offset from 0.

I spotted this problem when using https://github.com/krasserm/akka-persistence-cassandra/ - on app startup with an empty event log, funCQRS was passing an offset of 1 to my implementation of EventsSourceProvider, which caused problems as there was no offset of 1 in an empty event log.