### PR TITLE
Compatibility with akka/akka-stream 2.4.2-RC1

### DIFF
--- a/modules/akka/src/main/scala/io/funcqrs/akka/EventsSourceProvider.scala
+++ b/modules/akka/src/main/scala/io/funcqrs/akka/EventsSourceProvider.scala
@@ -1,5 +1,6 @@
 package io.funcqrs.akka
 
+import akka.NotUsed
 import akka.actor.ActorContext
 import akka.persistence.query.EventEnvelope
 import akka.stream.scaladsl.Source
@@ -10,7 +11,7 @@ import akka.stream.scaladsl.Source
  */
 trait EventsSourceProvider {
 
-  def source(offset: Long)(implicit context: ActorContext): Source[EventEnvelope, Unit]
+  def source(offset: Long)(implicit context: ActorContext): Source[EventEnvelope, NotUsed]
 
 }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,21 +18,21 @@ object Dependencies {
 
   //------------------------------------------------------------------------------------------------------------
   // Akka Module
-  val akkaVersion               =   "2.4.0"
+  val akkaVersion               =   "2.4.2-RC1"
   val akkaActor                 =   "com.typesafe.akka"           %%  "akka-actor"        % akkaVersion
   
   val akkaPersistence           =   "com.typesafe.akka"           %%  "akka-persistence"  % akkaVersion
   val akkaSlf4j                 =   "com.typesafe.akka"           %%  "akka-slf4j"        % akkaVersion
+  val akkaStreams               =   "com.typesafe.akka"           %%  "akka-stream"       % akkaVersion
   val akkaTestKit               =   "com.typesafe.akka"           %%  "akka-testkit"      % akkaVersion     % "test"
-  val akkaStreams               =   "com.typesafe.akka"           %%  "akka-stream-experimental"            % "1.0"
   val akkaPersistenceQuery      =   "com.typesafe.akka"           %%  "akka-persistence-query-experimental" % akkaVersion
 
-  val akkaPersistenceInMemory   =   "com.github.dnvriend"         %%  "akka-persistence-inmemory"           % "1.1.5"     % "test"
+  val akkaPersistenceInMemory   =   "com.github.dnvriend"         %%  "akka-persistence-inmemory"           % "1.2.2"     % "test"
 
   val akkaDeps = Seq(
-    libraryDependencies ++= Seq(akkaActor, akkaPersistence, akkaSlf4j),
+    libraryDependencies ++= Seq(akkaActor, akkaPersistence, akkaStreams, akkaSlf4j),
     // experimental
-    libraryDependencies ++= Seq(akkaPersistenceQuery, akkaStreams),
+    libraryDependencies ++= Seq(akkaPersistenceQuery),
     // test scope
     libraryDependencies ++= Seq(akkaTestKit, akkaPersistenceInMemory)
   )

--- a/samples/lottery/src/main/scala/lottery/domain/model/LotteryView.scala
+++ b/samples/lottery/src/main/scala/lottery/domain/model/LotteryView.scala
@@ -3,7 +3,7 @@ package lottery.domain.model
 import java.time.OffsetDateTime
 
 case class LotteryView(
-  name: String,
+    name: String,
     participants: List[LotteryView.Participant] = List(),
     winner: Option[String] = None,
     runDate: Option[OffsetDateTime] = None,

--- a/samples/lottery/src/main/scala/lottery/domain/service/LevelDbTaggedEventsSource.scala
+++ b/samples/lottery/src/main/scala/lottery/domain/service/LevelDbTaggedEventsSource.scala
@@ -1,5 +1,6 @@
 package lottery.domain.service
 
+import akka.NotUsed
 import akka.actor.ActorContext
 import akka.persistence.query.journal.leveldb.scaladsl.LeveldbReadJournal
 import akka.persistence.query.{ EventEnvelope, PersistenceQuery }
@@ -15,7 +16,7 @@ class LevelDbTaggedEventsSource(tag: Tag) extends EventsSourceProvider {
    * @param offset - initial offset to start read from
    * @return
    */
-  def source(offset: Long)(implicit context: ActorContext): Source[EventEnvelope, Unit] = {
+  def source(offset: Long)(implicit context: ActorContext): Source[EventEnvelope, NotUsed] = {
 
     val readJournal =
       PersistenceQuery(context.system)


### PR DESCRIPTION
* migrate akka related dependencies to newest version
* replace akka-stream-experimental dependency with akka-stream
* change EventsSourceProvider signature to use akka.NotUsed materialized value
* upgrade akka-persistence-inmemory dependency to make tests pass