### PR TITLE
Allow to configure passivation strategy per aggregate

### DIFF
--- a/modules/akka/src/main/resources/reference.conf
+++ b/modules/akka/src/main/resources/reference.conf
@@ -2,17 +2,18 @@ funcqrs {
 
   akka {
 
-    passivation-strategy {
-      class = "io.funcqrs.akka.MaxChildrenPassivationStrategy"
-      max-children.max = 40
-      max-children.kill-at-once = 20
-    }
-
     aggregates {
 
       # aggregate-name {
       #   events-per-snapshot = 200
       # }
+
+      passivation-strategy {
+        class = "io.funcqrs.akka.MaxChildrenPassivationStrategy"
+        max-children.max = 40
+        max-children.kill-at-once = 20
+        inactivity-timeout = 3600
+      }
 
       events-per-snapshot = 50
     }

--- a/modules/akka/src/main/scala/io/funcqrs/akka/AggregateManager.scala
+++ b/modules/akka/src/main/scala/io/funcqrs/akka/AggregateManager.scala
@@ -152,8 +152,8 @@ trait AggregateManager extends Actor
 
   private def killChildrenIfNecessary() =
     passivationStrategy match {
-      case x: MaxChildrenPassivationStrategySupport =>
-        val candidates = x.determineChildrenToKill(context.children)
+      case x: SelectionBasedPassivationStrategySupport =>
+        val candidates = x.selectChildrenToKill(context.children)
 
         val childrenToTerminate = candidates.filterNot(childrenBeingTerminated)
 

--- a/modules/akka/src/main/scala/io/funcqrs/akka/AggregateManager.scala
+++ b/modules/akka/src/main/scala/io/funcqrs/akka/AggregateManager.scala
@@ -1,15 +1,11 @@
 package io.funcqrs.akka
 
 import _root_.akka.actor._
-import com.typesafe.config.{ ConfigFactory, Config }
 import io.funcqrs._
 import io.funcqrs.akka.AggregateActor.KillAggregate
 import io.funcqrs.akka.AggregateManager.{ Exists, GetState }
 import io.funcqrs.behavior.Behavior
-
 import scala.concurrent.duration.Duration
-import scala.util.Try
-import scala.util.control.NonFatal
 
 object AggregateManager {
 
@@ -20,8 +16,6 @@ object AggregateManager {
   case class UntypedIdAndCommand(id: AggregateId, cmd: DomainCommand)
 
 }
-
-case class MaxChildren(max: Int, childrenToKillAtOnce: Int)
 
 /**
  * Base aggregate manager.
@@ -40,7 +34,9 @@ trait AggregateManager extends Actor
   private var childrenBeingTerminated: Set[ActorRef] = Set.empty
   private var pendingCommands: Seq[PendingCommand] = Nil
 
-  val passivationStrategy: PassivationStrategy = loadPassivationStrategy()
+  val passivationStrategy: PassivationStrategy = PassivationStrategy(self.path.name)
+
+  log.info(s"passivationStrategy=${passivationStrategy.toString}")
 
   override def receive: PartialFunction[Any, Unit] = {
     processCommand orElse defaultProcessCommand
@@ -147,116 +143,32 @@ trait AggregateManager extends Actor
    * Build Props for a new Aggregate Actor with the passed Id
    */
   def aggregateActorProps(id: Id): Props = {
-    Props(classOf[AggregateActor[Aggregate]], id, behavior(id), passivationStrategy.inactivityTimeout, context.self.path.name)
-  }
-
-  private def killChildrenIfNecessary() = {
-
-    val candidates = passivationStrategy.determineChildrenToKill(context.children)
-
-    val childrenToTerminate = candidates.filterNot(childrenBeingTerminated)
-
-    if (childrenToTerminate.nonEmpty) {
-      log.debug("Max manager children exceeded. Killing {} children.", childrenToTerminate.size)
-      childrenToTerminate foreach (_ ! KillAggregate)
-      childrenBeingTerminated ++= childrenToTerminate
+    val inactivityTimeout: Option[Duration] = passivationStrategy match {
+      case x: InactivityTimeoutPassivationStrategySupport => Some(x.inactivityTimeout)
+      case _ => None
     }
+    Props(classOf[AggregateActor[Aggregate]], id, behavior(id), inactivityTimeout, context.self.path.name)
   }
 
-  def loadPassivationStrategy() = {
+  private def killChildrenIfNecessary() =
+    passivationStrategy match {
+      case x: MaxChildrenPassivationStrategySupport =>
+        val candidates = x.determineChildrenToKill(context.children)
 
-    val config = context.system.settings.config
+        val childrenToTerminate = candidates.filterNot(childrenBeingTerminated)
 
-    Try(config.getString("funcqrs.akka.passivation-strategy.class")).flatMap { configuredClassName =>
-      Try {
-        //laad de class
-        Thread.currentThread().getContextClassLoader.loadClass(configuredClassName).newInstance().asInstanceOf[PassivationStrategy]
-      }.recover {
-
-        case e: ClassNotFoundException =>
-
-          log.warning(
-            """
-              |#=============================================================================
-              |# Could not load class configured for funcqrs.akka.passivation-strategy.class.
-              |# Are you sure {} is correct and in your classpath?
-              |#
-              |# Falling back to default passivation strategy
-              |#=============================================================================
-            """.stripMargin, configuredClassName
-          )
-
-          new MaxChildrenPassivationStrategy()
-
-        case _: InstantiationException | _: IllegalAccessException =>
-
-          log.warning(
-            """"
-              |#====================================================================================
-              |# Could not instantiate the passivation strategy.
-              |# Are you sure {} has a default constructor and is a subclass of PassivationStrategy?
-              |#
-              |# Falling back to default passivation strategy
-              |#====================================================================================
-            """.stripMargin, configuredClassName
-          )
-
-          new MaxChildrenPassivationStrategy()
-
-        case NonFatal(exp) =>
-          //class niet gevonden, laad de default
-          log.error("Unknown error while loading passivation strategy class. Falling back to default passivation strategy.", exp)
-          new MaxChildrenPassivationStrategy()
-      }
-    }.getOrElse(new MaxChildrenPassivationStrategy())
-  }
-
-}
-
-/**
- * Defines a passivation strategy for aggregate instances.
- */
-trait PassivationStrategy {
-
-  /**
-   * Determines how long they can idle in memory
-   *
-   * @return
-   */
-  def inactivityTimeout: Option[Duration] = None
-
-  /**
-   * Return all the children that may be killed.
-   *
-   * @param candidates all the children for a given AggregateManager
-   * @return
-   */
-  def determineChildrenToKill(candidates: Iterable[ActorRef]): Iterable[ActorRef]
-
-}
-
-class MaxChildrenPassivationStrategy extends PassivationStrategy {
-
-  val config: Config = ConfigFactory.load()
-
-  val max = {
-    Try(config.getInt("funcqrs.akka.passivation-strategy.max-children.max")).getOrElse(40)
-  }
-
-  val killAtOnce = {
-    Try(config.getInt("funcqrs.akka.passivation-strategy.max-children.kill-at-once")).getOrElse(20)
-  }
-
-  val maxChildren = MaxChildren(max = max, childrenToKillAtOnce = killAtOnce)
-
-  override def determineChildrenToKill(candidates: Iterable[ActorRef]): Iterable[ActorRef] = {
-    if (candidates.size > maxChildren.max) {
-      candidates.take(maxChildren.childrenToKillAtOnce)
-    } else {
-      Nil
+        if (childrenToTerminate.nonEmpty) {
+          log.debug("Max manager children exceeded. Killing {} children.", childrenToTerminate.size)
+          childrenToTerminate foreach (_ ! KillAggregate)
+          childrenBeingTerminated ++= childrenToTerminate
+          if (childrenToTerminate.nonEmpty) {
+            log.debug(s"Max manager children exceeded. Killing {} children.", childrenToTerminate.size)
+            childrenToTerminate foreach (_ ! KillAggregate)
+            childrenBeingTerminated ++= childrenToTerminate
+          }
+        }
+      case _ =>
     }
-  }
-
 }
 
 class ConfigurableAggregateManager[A <: AggregateLike](behaviorCons: A#Id => Behavior[A])

--- a/modules/akka/src/main/scala/io/funcqrs/akka/PassivationStrategies.scala
+++ b/modules/akka/src/main/scala/io/funcqrs/akka/PassivationStrategies.scala
@@ -1,0 +1,125 @@
+package io.funcqrs.akka
+
+import akka.actor.ActorRef
+import com.typesafe.config.{ ConfigFactory, Config }
+import com.typesafe.scalalogging.LazyLogging
+import scala.concurrent.duration._
+import scala.util.Try
+import scala.util.control.NonFatal
+
+/**
+ * Defines a passivation strategy for aggregate instances.
+ */
+sealed trait PassivationStrategy
+
+object PassivationStrategy extends LazyLogging {
+  val configPathPrefix = "funcqrs.akka.aggregates"
+  val configPathSuffix = "passivation-strategy"
+
+  def apply(aggregateName: String) = {
+    val _config = ConfigFactory.load()
+
+    val aggregateConfigPath = s"$configPathPrefix.${aggregateName.toLowerCase}.$configPathSuffix"
+
+    val configPath = if (_config.hasPath(aggregateConfigPath)) aggregateConfigPath else s"$configPathPrefix.$configPathSuffix"
+    val config: Config = _config.getConfig(configPath)
+
+    val configuredClassName = config.getString("class")
+
+    Try {
+      //laad de class
+      Thread.currentThread()
+        .getContextClassLoader
+        .loadClass(configuredClassName)
+        .getDeclaredConstructor(classOf[Config])
+        .newInstance(config)
+        .asInstanceOf[PassivationStrategy]
+    }.recover {
+      case e: ClassNotFoundException =>
+
+        logger.warn(
+          s"""
+               |#=============================================================================
+               |# Could not load class configured for {}.class.
+               |# Are you sure {} is correct and in your classpath?
+               |#
+               |# Falling back to default passivation strategy
+               |#=============================================================================
+          """.stripMargin, configPath, configuredClassName
+        )
+
+        new MaxChildrenPassivationStrategy(config)
+
+      case _: InstantiationException | _: IllegalAccessException =>
+
+        logger.warn(
+          """"
+              |#=======================================================================================
+              |# Could not instantiate the passivation strategy.
+              |# Are you sure {} has a constructor for Config and is a subclass of PassivationStrategy?
+              |#
+              |# Falling back to default passivation strategy
+              |#====================================================================================
+            """.stripMargin, configuredClassName
+        )
+
+        new MaxChildrenPassivationStrategy(config)
+
+      case NonFatal(exp) =>
+        //class niet gevonden, laad de default
+        logger.error("Unknown error while loading passivation strategy class. Falling back to default passivation strategy.", exp)
+        new MaxChildrenPassivationStrategy(config)
+    }.getOrElse(new MaxChildrenPassivationStrategy(config))
+  }
+}
+
+/**
+ * Defines a passivation strategy that will kill child actors when creating a new child
+ * will push us over a threshold
+ */
+trait MaxChildrenPassivationStrategySupport extends PassivationStrategy {
+  def max: Int
+  def killAtOnce: Int
+
+  def determineChildrenToKill(candidates: Iterable[ActorRef]): Iterable[ActorRef] = {
+    if (candidates.size > max) {
+      candidates.take(killAtOnce)
+    } else {
+      Nil
+    }
+  }
+
+  override def toString = s"${this.getClass.getSimpleName}(max=$max,killAtOnce=$killAtOnce)"
+}
+
+class MaxChildrenPassivationStrategy(config: Config) extends MaxChildrenPassivationStrategySupport {
+  override val max = {
+    Try(config.getInt("max-children.max")).getOrElse(40)
+  }
+
+  override val killAtOnce = {
+    Try(config.getInt("max-children.kill-at-once")).getOrElse(20)
+  }
+}
+
+trait InactivityTimeoutPassivationStrategySupport extends PassivationStrategy {
+
+  /**
+   * Determines how long they can idle in memory
+   *
+   * @return
+   */
+  def inactivityTimeout: Duration
+
+  override def toString = s"${this.getClass.getSimpleName}(inactivityTimeout=$inactivityTimeout)"
+}
+
+/**
+ * Defines a passivation strategy that will kill child actors when they have been idle for too long
+ */
+class InactivityTimeoutPassivationStrategy(config: Config) extends InactivityTimeoutPassivationStrategySupport {
+  override val inactivityTimeout: Duration = {
+    Try(Duration(config.getLong("inactivity-timeout"), SECONDS)).getOrElse(1.hours)
+  }
+
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.8
+sbt.version=0.13.11


### PR DESCRIPTION
When creating an aggregate manager you can now do

```scala
import io.funcqrs.akka.Implicits._

val manager = backend.actorOf {
  aggregate[Charger](Charger.behavior)
    .withName("ChargerManager")
    .withPassivationConfigPath("passivation-strategies.chargers")
}
```
To load the passivation config from a specific path