### PR TITLE
support play 2.5, because generated Formats are not compatible at runtime

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,6 +25,7 @@ lazy val root = Project(
   funCqrs,
   funCqrsAkka,
   funPlayJsonSupport,
+  funPlay25JsonSupport,
   funCqrsTestKit,
 //  shopApp,
   lotteryApp
@@ -50,7 +51,7 @@ lazy val funCqrsAkka = Project(
 
 
 
-// Play Json support ==============================
+// Play24 Json support ============================
 lazy val funPlayJsonSupport = Project(
   id = "fun-cqrs-play-json",
   base = file("modules/play-json"),
@@ -58,9 +59,17 @@ lazy val funPlayJsonSupport = Project(
 ) dependsOn (funCqrs % "compile->compile;test->test")
 //================================================
 
+// Play25 Json support ==========================
+lazy val funPlay25JsonSupport = Project(
+  id = "fun-cqrs-play25-json",
+  base = file("modules/play25-json"),
+  settings = mainDeps ++ Seq(libraryDependencies += play25Json)
+) dependsOn (funCqrs % "compile->compile;test->test")
+//================================================
 
 
-// Play Json support ==============================
+
+//Test kit =======================================
 lazy val funCqrsTestKit = Project(
   id = "fun-cqrs-test-kit",
   base = file("modules/tests"),

--- a/modules/play25-json/src/main/scala/io/funcqrs/PlayJsonFormats.scala
+++ b/modules/play25-json/src/main/scala/io/funcqrs/PlayJsonFormats.scala
@@ -1,0 +1,69 @@
+package io.funcqrs
+
+import java.time.OffsetDateTime
+import java.util.UUID
+
+import play.api.libs.json._
+
+import scala.util.Try
+
+trait PlayJsonFormats {
+
+  implicit val offsetDateTimeFormat = new Format[OffsetDateTime] {
+    override def reads(json: JsValue) = json match {
+      case JsString(s) => JsSuccess(OffsetDateTime.parse(s))
+      case _ => JsError("error.expected.jsstring")
+    }
+
+    override def writes(o: OffsetDateTime): JsValue = JsString(o.toString)
+  }
+
+  private def readUUID(value: String): JsResult[UUID] = {
+    Try(UUID.fromString(value))
+      .map(JsSuccess(_))
+      .getOrElse(JsError("error.expected.uuid"))
+  }
+
+  def readJsonId[T](json: JsValue)(toJsResult: (String) => JsResult[T]) = {
+    json match {
+      case JsString(id) => toJsResult(id)
+      case _ => JsError("error.expected.jsstring")
+    }
+  }
+
+  implicit val commandIdFormat = new Format[CommandId] {
+    override def reads(json: JsValue): JsResult[CommandId] =
+      readJsonId(json)(id => readUUID(id).map(CommandId))
+
+    override def writes(o: CommandId): JsValue = JsString(o.value.toString)
+  }
+
+  implicit val eventIdFormat = new Format[EventId] {
+    override def reads(json: JsValue): JsResult[EventId] =
+      readJsonId(json)(id => readUUID(id).map(EventId))
+
+    override def writes(o: EventId): JsValue = JsString(o.value.toString)
+  }
+
+  implicit val tagFormat = Json.format[Tag]
+
+  /**
+   * Json format for case classes that just wrap a String value. The json representation is just the string.
+   */
+  def simpleStringWrapper[W](creator: (String) => W)(extractor: W => String): Format[W] = {
+
+    new Format[W] {
+      override def reads(json: JsValue): JsResult[W] = {
+        json.validate[JsString].map {
+          jsString => creator(jsString.value)
+        }
+      }
+
+      override def writes(o: W): JsValue = {
+        JsString(extractor(o))
+      }
+    }
+  }
+}
+
+object PlayJsonFormats extends PlayJsonFormats

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -44,6 +44,7 @@ object Dependencies {
   //------------------------------------------------------------------------------------------------------------
   // Play Json support
   val playJson              =    "com.typesafe.play"          %% "play-json"          %  "2.4.4"
+  val play25Json            =    "com.typesafe.play"          %% "play-json"          %  "2.5.3"
   //------------------------------------------------------------------------------------------------------------
 
   val levelDb           =   "org.iq80.leveldb"            %   "leveldb"           % "0.7"


### PR DESCRIPTION
It should be possible to build the same module against different play versions, see https://github.com/WegenenVerkeer/atomium/blob/develop/project/AtomiumBuild.scala for example.