### PR TITLE
'exists' with predicate like Scala collections

### DIFF
--- a/modules/akka/src/test/scala/io/funcqrs/akka/AggregateManagerTest.scala
+++ b/modules/akka/src/test/scala/io/funcqrs/akka/AggregateManagerTest.scala
@@ -33,10 +33,10 @@ class AggregateManagerTest extends FlatSpecLike with Matchers with ScalaFutures 
 
     val userRef = backend.aggregateRef[User].forId(UserId.generate())
 
-    userRef.exists().futureValue shouldBe false
+    userRef.isInitialized.futureValue shouldBe false
     userRef ! CreateUser("João Ninguém", 30)
     eventually {
-      userRef.exists().futureValue shouldBe true
+      userRef.isInitialized.futureValue shouldBe true
     }
 
     eventually {
@@ -57,7 +57,7 @@ class AggregateManagerTest extends FlatSpecLike with Matchers with ScalaFutures 
 
     val userRef = backend.aggregateRef[User].forId(UserId.generate())
 
-    userRef.exists().futureValue shouldBe false
+    userRef.isInitialized.futureValue shouldBe false
   }
 
   it should "return true when enquiring for existent aggregate" in {
@@ -67,7 +67,26 @@ class AggregateManagerTest extends FlatSpecLike with Matchers with ScalaFutures 
     userRef ! CreateUser("John Doe", 30)
 
     eventually {
-      userRef.exists().futureValue shouldBe true
+      userRef.isInitialized.futureValue shouldBe true
+    }
+  }
+
+  it should "return predicate evaluation when enquiring for existent" in {
+    val userRef = backend.aggregateRef[User].forId(UserId.generate())
+
+    userRef ! CreateUser("Jane Doe", 26)
+
+    eventually {
+      userRef.exists(_.age < 30).futureValue shouldBe true
+      userRef.exists(_.age > 30).futureValue shouldBe false
+    }
+  }
+
+  it should "return false when enquiring for existent with predicate of non-existent aggregate" in {
+    val userRef = backend.aggregateRef[User].forId(UserId.generate())
+
+    eventually {
+      userRef.exists(_ => true).futureValue shouldBe false
     }
   }
 

--- a/modules/core/src/main/scala/io/funcqrs/AggregateRef.scala
+++ b/modules/core/src/main/scala/io/funcqrs/AggregateRef.scala
@@ -17,7 +17,13 @@ trait AggregateRef[A, C, E, F[_]] {
   def tell(cmd: C): Unit
 
   def state(): F[A]
-  def exists(): F[Boolean]
+
+  @deprecated(message = "use isInitialized for check Aggregate contains some state", since = "1.0.0")
+  def exists(): F[Boolean] = isInitialized
+
+  def exists(predicate: A => Boolean): F[Boolean]
+
+  def isInitialized: F[Boolean]
 
   def withAskTimeout(timeout: FiniteDuration): AggregateRef[A, C, E, Future]
 }

--- a/modules/tests/src/main/scala/io/funcqrs/test/backend/InMemoryBackend.scala
+++ b/modules/tests/src/main/scala/io/funcqrs/test/backend/InMemoryBackend.scala
@@ -119,7 +119,10 @@ class InMemoryBackend extends Backend[Identity] {
     def state(): Identity[A] =
       aggregateState.getOrElse(sys.error("Aggregate is not initialized"))
 
-    def exists(): Identity[Boolean] = aggregateState.isDefined
+    def isInitialized: Identity[Boolean] = aggregateState.isDefined
+
+    def exists(predicate: (A) => Boolean): Identity[Boolean] =
+      aggregateState.exists(predicate)
 
     def withAskTimeout(timeout: FiniteDuration): AggregateRef[A, C, E, Future] = new AsyncAggregateRef[A, C, E] {
 
@@ -133,7 +136,9 @@ class InMemoryBackend extends Backend[Identity] {
 
       def state(): Future[A] = Future.successful(self.state())
 
-      def exists(): Future[Boolean] = Future.successful(self.exists())
+      def isInitialized: Future[Boolean] = Future.successful(self.isInitialized)
+
+      def exists(predicate: (A) => Boolean): Future[Boolean] = Future.successful(self.exists(predicate))
     }
   }
 }


### PR DESCRIPTION
Deprecated `exists()` and introduced `isInitialized`.
Added `exists(predicate: A => Boolean): F[Boolean]`.
Solves #54 