### PR TITLE
#88 Fix termination logic by not allowing an aggregate actor to be ki…

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,5 +1,5 @@
 val snapshotSuffix = "-SNAPSHOT"
 
-version in ThisBuild := "0.4.11" //+ snapshotSuffix
+version in ThisBuild := "0.4.12" //+ snapshotSuffix
 
 isSnapshot := version.value.endsWith(snapshotSuffix)


### PR DESCRIPTION
…lled while waiting for a command result message. Kill messages are stashed in the Busy state and handled when we arrive in the Active state.